### PR TITLE
Don't report as unknown if cleringnummer matches

### DIFF
--- a/src/AccountFactory.php
+++ b/src/AccountFactory.php
@@ -2,11 +2,13 @@
 
 namespace byrokrat\banking;
 
+use byrokrat\banking\Exception\InvalidClearingNumberException;
 use byrokrat\banking\Rewriter\RewriterStrategy;
 use byrokrat\banking\Rewriter\RewriterFactory;
 use byrokrat\banking\Exception\UnableToCreateAccountException;
 use byrokrat\banking\Exception\InvalidAccountNumberException;
 use byrokrat\banking\Exception\InvalidCheckDigitException;
+use byrokrat\banking\Validator\ClearingValidator;
 
 /**
  * Account number factory
@@ -126,6 +128,15 @@ class AccountFactory
             } catch (InvalidAccountNumberException $exception) {
                 if ($exception instanceof InvalidCheckDigitException) {
                     $parseMap['exception'] = $exception;
+                }
+
+                if(!($exception instanceof InvalidClearingNumberException)) {
+                   $clearing_validator = $format->get_validator(ClearingValidator::class);
+                   if($clearing_validator) {
+                      if($clearing_validator->validateClearingNumber($number)) {
+                         $parseMap['exception'] = $exception;
+                      }
+                   }
                 }
 
                 foreach ($rewrites as $rewrite) {

--- a/src/Format.php
+++ b/src/Format.php
@@ -73,4 +73,26 @@ class Format
 
         return $account;
     }
+
+    public function has_validator($class_name)
+    {
+        foreach($this->validators as $validator) {
+            if(is_a($validator, $class_name)) {
+                return TRUE;
+            }
+        }
+
+        return FALSE;
+    }
+
+    public function get_validator($class_name)
+    {
+        foreach($this->validators as $validator) {
+            if(is_a($validator, $class_name)) {
+                return $validator;
+            }
+        }
+
+        return FALSE;
+    }
 }

--- a/src/Validator/ClearingValidator.php
+++ b/src/Validator/ClearingValidator.php
@@ -37,14 +37,18 @@ class ClearingValidator implements Validator
      */
     public function validate(AccountNumber $number)
     {
-        $clearing = intval($number->getClearingNumber());
+       $clearing = $number->getClearingNumber();
+       if(!$this->validateClearingNumber($clearing)) {
+          throw new InvalidClearingNumberException("Invalid clearing number $clearing in $number");
+       }
+    }
 
-        foreach ($this->clearingRanges as $clearingRange) {
-            if ($clearing >= $clearingRange[0] && $clearing <= $clearingRange[1]) {
-                return;
-            }
-        }
-
-        throw new InvalidClearingNumberException("Invalid clearing number $clearing in $number");
+    public function validateClearingNumber($clearing) {
+       foreach ($this->clearingRanges as $clearingRange) {
+          if ($clearing >= $clearingRange[0] && $clearing <= $clearingRange[1]) {
+             return true;
+          }
+       }
+       return false;
     }
 }

--- a/tests/AccountFactoryTest.php
+++ b/tests/AccountFactoryTest.php
@@ -3,6 +3,7 @@
 namespace byrokrat\banking;
 
 use byrokrat\banking\Exception\UnableToCreateAccountException;
+use byrokrat\banking\Validator\ClearingValidator;
 use Prophecy\Argument;
 
 /**
@@ -91,6 +92,7 @@ class AccountFactoryTest extends \PHPUnit_Framework_TestCase
         $format = $this->prophesize('byrokrat\banking\Format');
         $format->parse('NOT-VALID')->willThrow('byrokrat\banking\Exception\InvalidAccountNumberException');
         $format->parse('VALID')->willReturn($account);
+        $format->get_validator(ClearingValidator::class)->willReturn(false);
 
         $rewriter = $this->prophesize('byrokrat\banking\Rewriter\RewriterStrategy');
         $rewriter->rewrite('NOT-VALID')->willReturn('VALID');
@@ -138,6 +140,7 @@ class AccountFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $format = $this->prophesize('byrokrat\banking\Format');
         $format->parse(Argument::any())->willThrow('byrokrat\banking\Exception\InvalidClearingNumberException');
+        $format->get_validator(ClearingValidator::class)->willReturn(false);
 
         $factory = new AccountFactory([$format->reveal()], [], true, true);
 
@@ -160,6 +163,7 @@ class AccountFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $format = $this->prophesize('byrokrat\banking\Format');
         $format->parse(Argument::any())->willThrow('byrokrat\banking\Exception\InvalidCheckDigitException');
+        $format->get_validator(ClearingValidator::class)->willReturn(false);
 
         $factory = new AccountFactory([$format->reveal()], [], true, true);
 

--- a/tests/AccountFactoryTest.php
+++ b/tests/AccountFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace byrokrat\banking;
 
+use byrokrat\banking\Exception\UnableToCreateAccountException;
 use Prophecy\Argument;
 
 /**
@@ -144,6 +145,15 @@ class AccountFactoryTest extends \PHPUnit_Framework_TestCase
             BankNames::BANK_UNKNOWN,
             $factory->createAccount('1234,1234567')->getBankName()
         );
+    }
+
+
+    public function testWrongLength()
+    {
+        $factory = new AccountFactory;
+
+        $this->setExpectedException(UnableToCreateAccountException::class);
+        $factory->createAccount('3300,123456789');
     }
 
     public function testIgnoringUnknownWhenCheckDigitFails()


### PR DESCRIPTION
If i have the right cleringnumer, but the wrong lenth, I get no errors, I just get an Unknown bank.

One way to solve that would be to report all validation errors, if the clearingnumber match.

Works in my cases, hope it works for all cases.