### PR TITLE
composer.json: require-dev phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
             "byrokrat\\banking\\": "tests/"
         }
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
     "require": {
         "php": ">=5.5",
         "byrokrat/checkdigit": "~1.0",


### PR DESCRIPTION
Travis fails when phpunit/phpunit not installed, guess its no longer part of the other "require":s